### PR TITLE
Update romm.xml

### DIFF
--- a/rommapp/romm.xml
+++ b/rommapp/romm.xml
@@ -50,7 +50,7 @@
    [b]07-08-2024:[/b] Offical RomM template released in Unraid Community Applications store &#xD;
    </Changes>
    <Config Name="Port" Target="8080" Default="8080" Mode="tcp" Description="" Type="Port" Display="always" Required="false" Mask="false">8080</Config>
-   <Config Name="Library" Target="/romm/library/" Default="/romm/library" Mode="rw" Description="Game files" Type="Path" Display="always" Required="true" Mask="false"/>
+   <Config Name="Library" Target="/romm/library/" Default="/romm/library" Mode="rw" Description="Game files" Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/romm/library</Config>
    <Config Name="Resources" Target="/romm/resources/" Default="" Mode="rw" Description="Metadata storage (covers, screenshots, etc.)" Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/romm/resources</Config>
    <Config Name="Assets" Target="/romm/assets/" Default="" Mode="rw" Description="Uploaded saves, states, etc." Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/romm/assets</Config>
    <Config Name="Config" Target="/romm/config/" Default="" Mode="rw" Description="Folder for config.yml" Type="Path" Display="always" Required="false" Mask="false">/mnt/user/appdata/romm/config</Config>


### PR DESCRIPTION
This changes the default path for the library to point users to `/mnt/user/appdata/romm/library` instead of `/romm/library`. 

Just makes it match resources, assets and config so that users (me) don't accidentally point to root.